### PR TITLE
add tensorflow-macos

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,5 @@ numpy
 scipy
 jax
 jaxlib
-tensorflow
+tensorflow; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
### Summary
I added tensorflow-macos and modified requirements-dev.txt to work with all the platform including M1 Mac.

