### PR TITLE
Make `lib` explicit from `path`

### DIFF
--- a/arraylias/alias.py
+++ b/arraylias/alias.py
@@ -131,9 +131,9 @@ class Alias:
         """Return aliased library path.
 
         Args:
-            path: A function or module path to alias. If None the base module
+            path: A function or module path to alias. If ``None`` the base module
                   will be returned.
-            like: infer library based on type or object and statically dispatch to
+            like: Infer library based on type or object and statically dispatch to
                   that libraries function or module.
 
         Returns:
@@ -175,9 +175,9 @@ class Alias:
             func: The function to dispatch to for the specified array library.
                 If None this will return a decorator to apply to a function.
             lib: Optional, a name string to identify the array library.
-                 If None this will be set as the base module name of the
+                 If ``None`` this will be set as the base module name of the
                  arrays module.
-            path: Optional, the path for dispatching to this function. If None
+            path: Optional, the path for dispatching to this function. If ``None``
                   the name of the input function will be used.
 
         Returns:
@@ -252,12 +252,12 @@ class Alias:
             module: A module, namespace, or class to look for attributes
                     corresponding to the dispatched function name.
             lib: Optional, a name string to identify the array library.
-                 If None this will be set as the base module name of the
+                 If ``None`` this will be set as the base module name of the
                  arrays module.
             path: Optional, the path for the module. If empty this module
                   will be added to the base path for the library.
-            prefer: prioritize searching this module before previously
-                    registered modules for the current path (Default: False).
+            prefer: Prioritize searching this module before previously
+                    registered modules for the current path (Default: ``False``).
 
         .. note::
 
@@ -388,7 +388,7 @@ class Alias:
             lib: Optional, the name string to identify the array library.
                  If None the base function module will be used.
             path: Optional, the aliased path for this function.
-                  If None the function name will be used.
+                  If ``None`` the function name will be used.
 
         Returns:
             A function decorator to register a function if dispatched_function
@@ -480,7 +480,7 @@ class Alias:
         if not path:
             return AliasedModule(self, lib=libs[0])
 
-        # Auto-disaptching path
+        # Auto-dispatching path
         if libs == _AUTOLIB:
             return AliasedPath(self, path)
 

--- a/arraylias/alias.py
+++ b/arraylias/alias.py
@@ -8,7 +8,6 @@
 """Dispatcher class"""
 
 import functools
-import warnings
 from typing import Optional, Union, Callable, Tuple
 from types import ModuleType, FunctionType
 

--- a/arraylias/alias.py
+++ b/arraylias/alias.py
@@ -16,6 +16,9 @@ from arraylias.aliased import AliasedModule, AliasedPath
 from arraylias.exceptions import AliasError, LibraryError
 
 
+_AUTOLIB = ("auto",)
+
+
 @functools.wraps(functools.lru_cache)
 def method_lru_cache(maxsize: Optional[int] = 128, typed: bool = False) -> Callable:
     """Least-recently-used cache decorator for methods.
@@ -129,23 +132,22 @@ class Alias:
         """Return aliased library path.
 
         Args:
-            path: A library path to alias.
-            like: infer lib based on type or object.
+            path: A function or module path to alias. If None the base module
+                  will be returned.
+            like: infer library based on type or object and statically dispatch to
+                  that libraries function or module.
 
         Returns:
-            The aliased library, module, or function.
+            The aliased module or function.
 
         Raises:
             ValueError: if a specific array library is specified in both path
                         and the like kwarg is used.
         """
-        lib, path = self._split_lib_from_path(path)
         if like is not None:
-            if lib != "auto":
-                raise ValueError("like kwarg should not be used with a resolved library path.")
             libs = self.infer_libs(like)
         else:
-            libs = (lib,)
+            libs = _AUTOLIB
         return self._dispatch(libs, path)
 
     @method_lru_cache(1)
@@ -161,8 +163,8 @@ class Alias:
     def register_function(
         self,
         func: Optional[Callable] = None,
-        path: Optional[str] = None,
         lib: Optional[str] = None,
+        path: Optional[str] = None,
     ) -> Optional[Callable]:
         """Register an array function for aliasing.
 
@@ -173,17 +175,17 @@ class Alias:
         Args:
             func: The function to dispatch to for the specified array library.
                 If None this will return a decorator to apply to a function.
-            path: Optional, the path for dispatching to this function. If None
-                  the name of the input function will be used.
             lib: Optional, a name string to identify the array library.
                  If None this will be set as the base module name of the
                  arrays module.
+            path: Optional, the path for dispatching to this function. If None
+                  the name of the input function will be used.
 
         Returns:
             If func is None returns a decorator for registering a function.
             Otherwise returns None.
         """
-        decorator = self._register_function_decorator(path=path, lib=lib)
+        decorator = self._register_function_decorator(lib=lib, path=path)
         if func is None:
             return decorator
         return decorator(func)
@@ -241,8 +243,8 @@ class Alias:
     def register_module(
         self,
         module: ModuleType,
-        path: Optional[str] = None,
         lib: Optional[str] = None,
+        path: Optional[str] = None,
         prefer: bool = False,
     ):
         """Register a module for looking up array functions.
@@ -250,11 +252,11 @@ class Alias:
         Args:
             module: A module, namespace, or class to look for attributes
                     corresponding to the dispatched function name.
-            path: Optional, the path for the module. If empty this module
-                  will be added to the base path for the library.
             lib: Optional, a name string to identify the array library.
                  If None this will be set as the base module name of the
                  arrays module.
+            path: Optional, the path for the module. If empty this module
+                  will be added to the base path for the library.
             prefer: prioritize searching this module before previously
                     registered modules for the current path (Default: False).
 
@@ -265,18 +267,9 @@ class Alias:
             module being returned.
         """
         # Infer default lib from module name or path prefix
-        path_lib, path = self._split_lib_from_path(path)
         if lib is None:
-            if path_lib != "auto":
-                lib = path_lib
-            else:
-                lib = _lib_from_object(module)
-        elif path_lib != "auto":
-            warnings.warn(
-                "Module lib is specified in both lib and path kwargs, "
-                f"using lib kwarg value {lib} and path value {path}",
-                UserWarning,
-            )
+            lib = _lib_from_object(module)
+        path = path or ""
 
         # Register library and paths
         self._register_lib(lib)
@@ -388,15 +381,15 @@ class Alias:
                 mods[sub_path] = []
 
     def _register_function_decorator(
-        self, path: Optional[str] = None, lib: Optional[str] = None
+        self, lib: Optional[str] = None, path: Optional[str] = None
     ) -> Callable:
         """Return a decorator to register a function.
 
         Args:
-            path: Optional, the aliased path for this function.
-                  If None the function name will be used.
             lib: Optional, the name string to identify the array library.
                  If None the base function module will be used.
+            path: Optional, the aliased path for this function.
+                  If None the function name will be used.
 
         Returns:
             A function decorator to register a function if dispatched_function
@@ -404,20 +397,17 @@ class Alias:
         """
 
         def decorator(func):
-            func_path = path if path else func.__name__
-            func_lib, func_path = self._split_lib_from_path(func_path)
-            if lib:
-                if func_lib != "auto":
-                    warnings.warn(
-                        "Function lib is specified in both lib and path kwargs, "
-                        f"using lib kwarg value {lib} and path value {func_path}",
-                        UserWarning,
-                    )
-                func_lib = lib
-            elif func_lib == "auto":
+            if lib is None:
                 func_lib = _lib_from_object(func)
+            else:
+                func_lib = lib
             if func_lib not in self._libs:
                 raise LibraryError(f"Array library {func_lib} is not a registered library.")
+
+            if path is None:
+                func_path = self._trim_lib_from_path(func.__name__)
+            else:
+                func_path = path
 
             # Register sub paths if this is a module function
             split_path = func_path.rsplit(".", 1)
@@ -443,12 +433,10 @@ class Alias:
         """
 
         def decorator(func):
-            func_path = path if path else func.__name__
-            func_lib, func_path = self._split_lib_from_path(func_path)
-            if func_lib != "auto":
-                raise AliasError(
-                    f"Fallback function path {path} should not contain a registered lib {func_lib}"
-                )
+            if path is None:
+                func_path = self._trim_lib_from_path(func.__name__)
+            else:
+                func_path = path
             self._fallbacks[func_path] = func
             self.cache_clear()
             return func
@@ -468,12 +456,10 @@ class Alias:
         """
 
         def decorator(func):
-            func_path = path if path else func.__name__
-            func_lib, func_path = self._split_lib_from_path(func_path)
-            if func_lib != "auto":
-                raise AliasError(
-                    f"Default function path {path} should not contain a registered lib {func_lib}"
-                )
+            if path is None:
+                func_path = self._trim_lib_from_path(func.__name__)
+            else:
+                func_path = path
             self._defaults[func_path] = func
             self.cache_clear()
             return func
@@ -496,7 +482,7 @@ class Alias:
             return AliasedModule(self, lib=libs[0])
 
         # Auto-disaptching path
-        if libs == ("auto",):
+        if libs == _AUTOLIB:
             return AliasedPath(self, path)
 
         # Static dispatching for given libs and path
@@ -574,18 +560,17 @@ class Alias:
         return tuple()
 
     @method_lru_cache()
-    def _split_lib_from_path(self, path: Union[str, None]) -> Tuple[str, str]:
+    def _trim_lib_from_path(self, path: Optional[str]) -> str:
         """Split lib from path string if present."""
         if path is None:
-            return "auto", ""
+            return ""
 
         split = path.split(".", 1)
         if split[0] in self._libs:
-            lib = split[0]
             tail = "" if len(split) == 1 else split[1]
-            return lib, tail
+            return tail
 
-        return "auto", path
+        return path
 
 
 @functools.lru_cache()

--- a/arraylias/numpy_alias/register_jax.py
+++ b/arraylias/numpy_alias/register_jax.py
@@ -43,8 +43,8 @@ def register_jax(alias):
             return jax.numpy.array(array, copy=True, order=order)
 
         # Register Jax linalg functions
-        alias.register_module(jax.numpy.linalg, path="linalg", lib=lib)
-        alias.register_module(jax.scipy.linalg, path="linalg", lib=lib)
+        alias.register_module(jax.numpy.linalg, lib, path="linalg")
+        alias.register_module(jax.scipy.linalg, lib, path="linalg")
 
         return True
 

--- a/arraylias/numpy_alias/register_numpy.py
+++ b/arraylias/numpy_alias/register_numpy.py
@@ -51,8 +51,8 @@ def register_numpy(alias, register_numbers=True, prefer_scipy=False):
         try:
             import scipy.linalg
 
-            alias.register_module(numpy.linalg, path="linalg", lib=lib)
-            alias.register_module(scipy.linalg, path="linalg", lib=lib, prefer=prefer_scipy)
+            alias.register_module(numpy.linalg, lib, path="linalg")
+            alias.register_module(scipy.linalg, lib, path="linalg", prefer=prefer_scipy)
 
         except ModuleNotFoundError:
             pass

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -92,10 +92,11 @@ kwarg of the call method.
 
 .. code-block:: python
 
-   # The following are all equivalent
-   tensordot = alias("numpy.tensordot")
+   # The following are equivalent
    tensordot = alias("tensordot", like="numpy")
-   tensordot = alias("numpy").tensordot
+
+   np = alias(like="numpy")
+   tensordot = np.tensordot
 
 The ``like`` kwarg can also be passed a type or object to infer the
 library from, for example

--- a/test/alias/test_register_functions.py
+++ b/test/alias/test_register_functions.py
@@ -10,7 +10,7 @@
 
 import unittest
 import numpy
-from arraylias import Alias, AliasError
+from arraylias import Alias
 
 
 class TestRegisterFunction(unittest.TestCase):

--- a/test/alias/test_register_functions.py
+++ b/test/alias/test_register_functions.py
@@ -54,19 +54,9 @@ class TestRegisterFunction(unittest.TestCase):
 
         alias = Alias()
         alias.register_type(numpy.ndarray, "test_lib")
-        alias.register_function(numpy.sin, path="test_lib.some.path.sin")
+        alias.register_function(numpy.sin, lib="test_lib", path="some.path.sin")
         func = alias("some.path.sin", like="test_lib")
         self.assertEqual(func, numpy.sin)
-
-    def test_register_function_lib_path_warning(self):
-        """Test register_function with custom name and lib"""
-        alias = Alias()
-        alias.register_type(numpy.ndarray, "test_lib")
-
-        with self.assertWarns(UserWarning):
-            alias.register_function(numpy.sin, path="test_lib.sin", lib="test_lib")
-            func = alias("sin", like="test_lib")
-            self.assertEqual(func, numpy.sin)
 
     def test_register_function_custom(self):
         """Test register_function"""
@@ -158,14 +148,6 @@ class TestRegisterFunction(unittest.TestCase):
         func = alias("some.module.path.sin", like="test_lib")
         self.assertEqual(func, numpy.sin)
 
-    def test_register_fallback_invalid_path(self):
-        """Test register_fallback with invalid path"""
-
-        alias = Alias()
-        alias.register_type(numpy.ndarray, "numpy")
-        with self.assertRaises(AliasError):
-            alias.register_fallback(numpy.sin, path="numpy.sin")
-
     def test_register_fallback_custom(self):
         """Test register_fallback"""
         alias = Alias()
@@ -240,14 +222,6 @@ class TestRegisterFunction(unittest.TestCase):
         alias.register_default(numpy.sin, path="some.module.path.sin")
         func = alias("some.module.path.sin", like="test_lib")
         self.assertEqual(func, numpy.sin)
-
-    def test_register_default_invalid_path(self):
-        """Test register_default with custom name and lib"""
-
-        alias = Alias()
-        alias.register_type(numpy.ndarray, "numpy")
-        with self.assertRaises(AliasError):
-            alias.register_default(numpy.sin, path="numpy.sin")
 
     def test_register_default_custom(self):
         """Test register_default"""

--- a/test/alias/test_register_module.py
+++ b/test/alias/test_register_module.py
@@ -42,7 +42,7 @@ class TestRegisterFunction(unittest.TestCase):
 
         alias = Alias()
         alias.register_type(numpy.ndarray)
-        alias.register_module(numpy, path="numpy.custom.path")
+        alias.register_module(numpy, path="custom.path")
         func = alias("custom.path.sin", like=numpy.ndarray)
         self.assertEqual(func, numpy.sin)
 
@@ -54,28 +54,13 @@ class TestRegisterFunction(unittest.TestCase):
         func = alias("sin", like=numpy.ndarray)
         self.assertEqual(func, numpy.sin)
 
-    def test_register_module_path_lib(self):
-        """Test register_module method with path"""
-        alias = Alias()
-        alias.register_type(numpy.ndarray, "test_lib")
-        alias.register_module(numpy, path="test_lib.custom.path")
-        func = alias("custom.path.sin", like=numpy.ndarray)
-        self.assertEqual(func, numpy.sin)
-
     def test_register_module_path_and_lib(self):
         """Test register_module method with path and lib"""
         alias = Alias()
         alias.register_type(numpy.ndarray, "test_lib")
-        alias.register_module(numpy, path="custom.path", lib="test_lib")
+        alias.register_module(numpy, lib="test_lib", path="custom.path")
         func = alias("custom.path.sin", like=numpy.ndarray)
         self.assertEqual(func, numpy.sin)
-
-    def test_register_module_path_and_lib_warning(self):
-        """Test register_module method with path and lib"""
-        alias = Alias()
-        alias.register_type(numpy.ndarray, "test_lib")
-        with self.assertWarns(UserWarning):
-            alias.register_module(numpy, path="test_lib.custom.path", lib="test_lib")
 
     def test_register_module_flatten(self):
         """Test using register_module to flatten modules"""

--- a/test/alias/test_register_module.py
+++ b/test/alias/test_register_module.py
@@ -62,6 +62,14 @@ class TestRegisterFunction(unittest.TestCase):
         func = alias("custom.path.sin", like=numpy.ndarray)
         self.assertEqual(func, numpy.sin)
 
+    def test_register_module_same_path_and_lib(self):
+        """Test register_module method with path and lib"""
+        alias = Alias()
+        alias.register_type(numpy.ndarray)
+        alias.register_module(numpy, path="numpy")
+        func = alias("numpy.sin", like=numpy.ndarray)
+        self.assertEqual(func, numpy.sin)
+
     def test_register_module_flatten(self):
         """Test using register_module to flatten modules"""
         alias = Alias()

--- a/test/alias/test_register_type.py
+++ b/test/alias/test_register_type.py
@@ -128,7 +128,7 @@ class TestRegisterType(unittest.TestCase):
         self.assertEqual(alias.infer_libs(tuple(nested)), ("int_lib",))
         self.assertEqual(alias.infer_libs(tuple(nested), allow_sequence=False), tuple())
 
-    def test_register_type_autolib(self):
+    def test_register_type__AUTOLIB(self):
         """Test automatic inference of lib from base module name"""
         alias = Alias()
         alias.register_type(complex)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This removes inferring library from path, so it has to be provided explicitly. This avoids issues where a path might contain a module with the same name as the library.


### Details and comments


